### PR TITLE
Fix: Correct getenv call for GEMINI_API_KEY in config/settings.py

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -6,7 +6,7 @@ from dotenv import load_dotenv
 load_dotenv()
 
 
-GEMINI_API_KEY = os.getenv("")
+GEMINI_API_KEY = os.getenv("GEMINI_API_KEY")
 
 
 


### PR DESCRIPTION
This pull request fixes an issue in `config/settings.py` where the `GEMINI_API_KEY` was being read incorrectly.

**Problem:**
The line `GEMINI_API_KEY = os.getenv("")` was used, which does not correctly fetch the environment variable named "GEMINI_API_KEY". This resulted in the API key not being loaded from the `.env` file or system environment variables, causing a `ValueError` later when the key was expected.

**Solution:**
I have changed the line to `GEMINI_API_KEY = os.getenv("GEMINI_API_KEY")`. This ensures that the correct environment variable is accessed.

With this change, the application can now properly load the `GEMINI_API_KEY` as intended. I have tested this locally, and the warning/error related to the missing API key is resolved.