### PR TITLE
Fix fixed child id

### DIFF
--- a/task_manager/agent.py
+++ b/task_manager/agent.py
@@ -121,7 +121,7 @@ class TaskManagerAgent(TaskManagerInterface):
             generation_tasks = []
             for i, parent in enumerate(parents):
                 for j in range(num_offspring_per_parent):
-                    child_id = f"{self.task_definition.id}_gen{gen}_child{len(offspring_population)}"
+                    child_id = f"{self.task_definition.id}_gen{gen}_child{i}_{j}"
                     generation_tasks.append(self.generate_offspring(parent, gen, child_id))
             
             generated_offspring_results = await asyncio.gather(*generation_tasks, return_exceptions=True)


### PR DESCRIPTION
```
generation_tasks = []
for i, parent in enumerate(parents):
        for j in range(num_offspring_per_parent):
            child_id = f"{self.task_definition.id}_gen{gen}_child{len(offspring_population)}"
            generation_tasks.append(self.generate_offspring(parent, gen, child_id))
            
generated_offspring_results = await asyncio.gather(*generation_tasks, return_exceptions=True)
```

Child program id is always fixed to 0 because length of offspring_population stays 0 until tasks are gathered.
When we save program, previous program will be overwritten
